### PR TITLE
たまにGPTがlukの値を"LUK"と返すので, 検証用の関数を追加

### DIFF
--- a/api/chat_gpt/status_generation.py
+++ b/api/chat_gpt/status_generation.py
@@ -1,5 +1,5 @@
 from openai import OpenAI
-
+from utils.car_data_validator import validate_luk
 client = OpenAI()
 
 
@@ -17,7 +17,7 @@ async def status_generate_chatgpt(text:str):
     )
     response = res.choices[0].message.content
     text_split = response.split('|')
-    luk = text_split[0]
+    luk = validate_luk(text_split[0])
     name = text_split[1]
     text_car_status = text_split[2]
     return [luk,name,text_car_status]

--- a/api/utils/car_data_validator.py
+++ b/api/utils/car_data_validator.py
@@ -1,0 +1,29 @@
+import random
+
+def validate_luk(luk: str) -> int:
+    """
+        車のLUKの値を検証する関数
+        Args:
+            luk (str): LUKの値
+        Returns:
+            int: LUKの値
+        Raises:
+            ValueError: LUKがint型または'LUK'でない場合
+        Behavior:
+            LUKが0-6の文字型の数字の場合、int型に変換して返す
+            LUKが"LUK"の場合、ランダムなLUKの値を返す
+    """
+    if luk == "LUK":
+        luk_rand = random.randint(0, 6)
+        print("luk is", luk, "So, it's updated to", luk_rand)
+        return luk_rand
+    else:
+        try:
+            luk = int(luk)
+            if 0 <= luk <= 6:
+                print("luk is", luk)
+                return luk
+            else:
+                raise ValueError("LUK is out of range")
+        except ValueError:
+            raise ValueError("LUK is not int type")


### PR DESCRIPTION
## 目的
たまにGPTがlukの値を"LUK"と返すので, 検証用の関数を追加
## 概要
GPTが車のLUKを決定するときに、たまに"LUK"という文字列を返却するため
"LUK"が返ってきた時はランダムに0-6の値を返す検証用の関数を追加した
## 確認項目

- [x] `/test/car/status`を何度か叩き以下の2つの標準出力が得られることを確認する

```
# GPTからintが返却された場合の標準出力
FastAPI  | luk is 2
```
```
# GPTから"LUK"が返却された場合の標準出力
FastAPI  | luk is LUK So, it's updated to 1
```

## 不安・相談
