### PR TITLE
ユーザーの入力したトークン数を検証するためのvalidate関数を追加

### DIFF
--- a/api/api_test/no_rembg.py
+++ b/api/api_test/no_rembg.py
@@ -1,0 +1,77 @@
+from fastapi import APIRouter, Security
+from fastapi.responses import Response
+from chat_gpt.status_generation import status_generate_chatgpt
+from utils.translation import translation
+from utils.auth import validate_api_key
+from transformers import GPT2Tokenizer
+from base64 import b64encode
+from utils.car_data_validator import validate_token_count
+from openai import OpenAI
+import asyncio
+import requests
+
+tokenizer = GPT2Tokenizer.from_pretrained("gpt2")
+
+router = APIRouter()
+
+client = OpenAI()
+
+
+@router.get("/{player}/car/data")
+def test_make_car_no_rembg(player: str,text: str, api_key: str = Security(validate_api_key)):
+
+
+    with open("api_test/gpt_car.bin","rb") as f:
+       binary_data = f.read()
+    
+    name = 'Feline Fury'
+    luk = '4'
+    text_car_status = '洗練されたエクステリア、居心地の良いインテリア、そしてエンターテイメント用の内蔵レーザーポインターなどの先進機能で、この車は猫愛好家のために完璧にデザインされている。すべてのドライブがキャットウォークのように感じられること請け合いだ。ニャーベラス！'
+    
+    return {"car_img": b64encode(binary_data),"name": name,"luk": luk,"text_car_status": text_car_status}
+
+
+
+@router.get("/{player}/car/data")
+async def make_car(player: str,text: str, api_key: str = Security(validate_api_key)):
+
+    text_en = translation(text,'JA','EN-US')
+    
+    if validate_token_count(text_en,5):
+        url_car_img, [luk,name,text_car_status] = await asyncio.gather(
+            image_generate_chatgpt_no_rembg(text_en),
+            status_generate_chatgpt(text_en)
+        )
+
+    
+    text_jp = translation(text_car_status,'EN','JA')
+
+
+    return {"url_car_img": url_car_img,"name": name,"luk": luk,"text_car_status": text_jp}
+
+def shaping_prompts_car_img(text:str):
+
+    prompt="Draw a single car with a design based on the specified theme.#Theme# "+ text + " #Condition 1# Background is white. #Condition 2# The outline of the car is highlighted in black. #Condition 3# The theme must be reflected in the car's design, colors and decorations. For example, if the theme is [Cats are God!] then the car should include features and details that are reminiscent of cats (e.g., cat ears and tail shape, cat hair pattern design, etc.). However, the theme is not limited to this example, and the car design should be modified according to the theme. #Condition 4# Please depict only one car clearly, with no other objects displayed in the background."
+    return prompt
+
+
+async def image_generate_chatgpt_no_rembg(text:str):
+    
+    text_prompt = shaping_prompts_car_img(text)
+    #modelはdell-e2
+    response =  client.images.generate(
+                        model   = "dall-e-2",   # モデル  
+                        prompt  = text_prompt,         # 画像生成に用いる説明文章         
+                        n       = 1,            # 何枚の画像を生成するか  
+                        #size="1024x1024",
+                        size="256x256",
+                        quality="standard",
+                    )
+    
+    image_url = response.data[0].url
+
+    # URLから画像(バイナリ)を取得
+    car_img_binary = requests.get(image_url).content
+    
+    
+    return b64encode(car_img_binary) # 画像(バイナリ)をbase64に変換して返す

--- a/api/api_test/test_car_data.py
+++ b/api/api_test/test_car_data.py
@@ -29,6 +29,21 @@ def test_make_car(player: str,text: str, api_key: str = Security(validate_api_ke
     
     return {"car_img": b64encode(binary_data),"name": name,"luk": luk,"text_car_status": text_car_status}
 
+"""
+
+@router.get("/{player}/car/data")
+def test_make_car_no_rembg(player: str,text: str, api_key: str = Security(validate_api_key)):
+
+
+    with open("api_test/gpt_car.bin","rb") as f:
+       binary_data = f.read()
+    
+    name = 'Feline Fury'
+    luk = '4'
+    text_car_status = '洗練されたエクステリア、居心地の良いインテリア、そしてエンターテイメント用の内蔵レーザーポインターなどの先進機能で、この車は猫愛好家のために完璧にデザインされている。すべてのドライブがキャットウォークのように感じられること請け合いだ。ニャーベラス！'
+    
+    return {"car_img": b64encode(binary_data),"name": name,"luk": luk,"text_car_status": text_car_status}
+"""
 
 @router.get("/test/car/status")
 async def test_make_car_status(text: str, api_key: str = Security(validate_api_key)):

--- a/api/api_test/test_car_data.py
+++ b/api/api_test/test_car_data.py
@@ -9,7 +9,6 @@ from io import BytesIO
 from base64 import b64encode
 
 tokenizer = GPT2Tokenizer.from_pretrained("gpt2")
-
 router = APIRouter()
 
 
@@ -29,21 +28,6 @@ def test_make_car(player: str,text: str, api_key: str = Security(validate_api_ke
     
     return {"car_img": b64encode(binary_data),"name": name,"luk": luk,"text_car_status": text_car_status}
 
-"""
-
-@router.get("/{player}/car/data")
-def test_make_car_no_rembg(player: str,text: str, api_key: str = Security(validate_api_key)):
-
-
-    with open("api_test/gpt_car.bin","rb") as f:
-       binary_data = f.read()
-    
-    name = 'Feline Fury'
-    luk = '4'
-    text_car_status = '洗練されたエクステリア、居心地の良いインテリア、そしてエンターテイメント用の内蔵レーザーポインターなどの先進機能で、この車は猫愛好家のために完璧にデザインされている。すべてのドライブがキャットウォークのように感じられること請け合いだ。ニャーベラス！'
-    
-    return {"car_img": b64encode(binary_data),"name": name,"luk": luk,"text_car_status": text_car_status}
-"""
 
 @router.get("/test/car/status")
 async def test_make_car_status(text: str, api_key: str = Security(validate_api_key)):

--- a/api/chat_gpt/car_data.py
+++ b/api/chat_gpt/car_data.py
@@ -27,22 +27,3 @@ async def make_car(player: str,text: str, api_key: str = Security(validate_api_k
 
 
     return {"url_car_img": url_car_img,"name": name,"luk": luk,"text_car_status": text_jp}
-'''
-
-@router.get("/{player}/car/data")
-async def make_car(player: str,text: str, api_key: str = Security(validate_api_key)):
-
-    text_en = translation(text,'JA','EN-US')
-    
-    if validate_token_count(text_en,5):
-        url_car_img, [luk,name,text_car_status] = await asyncio.gather(
-            image_generate_chatgpt_no_rembg(text_en),
-            status_generate_chatgpt(text_en)
-        )
-
-    
-    text_jp = translation(text_car_status,'EN','JA')
-
-
-    return {"url_car_img": url_car_img,"name": name,"luk": luk,"text_car_status": text_jp}
-'''

--- a/api/chat_gpt/car_data.py
+++ b/api/chat_gpt/car_data.py
@@ -1,31 +1,48 @@
 from fastapi import APIRouter, Security
 from fastapi.responses import Response
-from transformers import GPT2Tokenizer
 from chat_gpt.image_generation import image_generate_chatgpt
+from chat_gpt.image_generation import image_generate_chatgpt_no_rembg
 from utils.auth import validate_api_key
 from chat_gpt.status_generation import status_generate_chatgpt
 from utils.translation import translation
+from utils.car_data_validator import validate_token_count
 import asyncio
 
-tokenizer = GPT2Tokenizer.from_pretrained("gpt2")
 router = APIRouter()
+
 
 @router.get("/{player}/car/data")
 async def make_car(player: str,text: str, api_key: str = Security(validate_api_key)):
 
     text_en = translation(text,'JA','EN-US')
-    tokens = tokenizer.tokenize(text_en)
     
-    if len(tokens)<=30:
+    if validate_token_count(text_en,30):
         url_car_img, [luk,name,text_car_status] = await asyncio.gather(
             image_generate_chatgpt(text_en),
             status_generate_chatgpt(text_en)
         )
-    else:
-        url_car_img = ''
-        text_car_status = ''
+
     
     text_jp = translation(text_car_status,'EN','JA')
 
 
     return {"url_car_img": url_car_img,"name": name,"luk": luk,"text_car_status": text_jp}
+'''
+
+@router.get("/{player}/car/data")
+async def make_car(player: str,text: str, api_key: str = Security(validate_api_key)):
+
+    text_en = translation(text,'JA','EN-US')
+    
+    if validate_token_count(text_en,5):
+        url_car_img, [luk,name,text_car_status] = await asyncio.gather(
+            image_generate_chatgpt_no_rembg(text_en),
+            status_generate_chatgpt(text_en)
+        )
+
+    
+    text_jp = translation(text_car_status,'EN','JA')
+
+
+    return {"url_car_img": url_car_img,"name": name,"luk": luk,"text_car_status": text_jp}
+'''

--- a/api/chat_gpt/car_data.py
+++ b/api/chat_gpt/car_data.py
@@ -1,7 +1,6 @@
 from fastapi import APIRouter, Security
 from fastapi.responses import Response
 from chat_gpt.image_generation import image_generate_chatgpt
-from chat_gpt.image_generation import image_generate_chatgpt_no_rembg
 from utils.auth import validate_api_key
 from chat_gpt.status_generation import status_generate_chatgpt
 from utils.translation import translation

--- a/api/chat_gpt/image_generation.py
+++ b/api/chat_gpt/image_generation.py
@@ -14,6 +14,7 @@ def shaping_prompts_car_img(text:str):
     prompt="Draw a single car with a design based on the specified theme.#Theme# "+ text + " #Condition 1# Background is white. #Condition 2# The outline of the car is highlighted in black. #Condition 3# The theme must be reflected in the car's design, colors and decorations. For example, if the theme is [Cats are God!] then the car should include features and details that are reminiscent of cats (e.g., cat ears and tail shape, cat hair pattern design, etc.). However, the theme is not limited to this example, and the car design should be modified according to the theme. #Condition 4# Please depict only one car clearly, with no other objects displayed in the background."
     return prompt
 
+
 async def image_generate_chatgpt(text:str):
     
     text_prompt = shaping_prompts_car_img(text)
@@ -39,5 +40,27 @@ async def image_generate_chatgpt(text:str):
     binary_image = buffered.getvalue() # 画像(バイナリ)を取得
     
     return b64encode(binary_image) # 画像(バイナリ)をbase64に変換して返す
+"""
 
+async def image_generate_chatgpt_no_rembg(text:str):
+    
+    text_prompt = shaping_prompts_car_img(text)
+    #modelはdell-e2
+    response =  client.images.generate(
+                        model   = "dall-e-2",   # モデル  
+                        prompt  = text_prompt,         # 画像生成に用いる説明文章         
+                        n       = 1,            # 何枚の画像を生成するか  
+                        #size="1024x1024",
+                        size="256x256",
+                        quality="standard",
+                    )
+    
+    image_url = response.data[0].url
+
+    # URLから画像(バイナリ)を取得
+    car_img_binary = requests.get(image_url).content
+    
+    
+    return b64encode(car_img_binary) # 画像(バイナリ)をbase64に変換して返す
+"""
 

--- a/api/chat_gpt/image_generation.py
+++ b/api/chat_gpt/image_generation.py
@@ -40,27 +40,5 @@ async def image_generate_chatgpt(text:str):
     binary_image = buffered.getvalue() # 画像(バイナリ)を取得
     
     return b64encode(binary_image) # 画像(バイナリ)をbase64に変換して返す
-"""
 
-async def image_generate_chatgpt_no_rembg(text:str):
-    
-    text_prompt = shaping_prompts_car_img(text)
-    #modelはdell-e2
-    response =  client.images.generate(
-                        model   = "dall-e-2",   # モデル  
-                        prompt  = text_prompt,         # 画像生成に用いる説明文章         
-                        n       = 1,            # 何枚の画像を生成するか  
-                        #size="1024x1024",
-                        size="256x256",
-                        quality="standard",
-                    )
-    
-    image_url = response.data[0].url
-
-    # URLから画像(バイナリ)を取得
-    car_img_binary = requests.get(image_url).content
-    
-    
-    return b64encode(car_img_binary) # 画像(バイナリ)をbase64に変換して返す
-"""
 

--- a/api/chat_gpt/status_generation.py
+++ b/api/chat_gpt/status_generation.py
@@ -1,5 +1,5 @@
 from openai import OpenAI
-from utils.car_data_validator import validation_element_car_data
+from utils.car_data_validator import validate_car_data
 client = OpenAI()
 
 
@@ -9,7 +9,7 @@ async def status_generate_chatgpt(text:str):
     text_split:list = []
 
 
-    while(validation_element_car_data(text_split,number_of_generation)):
+    while(not(validate_car_data(text_split,number_of_generation))):
         res = client.chat.completions.create(
         model="gpt-3.5-turbo",
         messages=[

--- a/api/utils/car_data_validator.py
+++ b/api/utils/car_data_validator.py
@@ -1,17 +1,19 @@
 import random
 from fastapi import  HTTPException,status
+from transformers import GPT2Tokenizer
 
-def validation_element_car_data(result:list,error_count:int):
+def validate_car_data(result:list,error_count:int) -> bool:
 
     """
         ChatGPTが出力した車のステータスがフォーマットに則っているか確認
         3回失敗したらエラーを出力
         Args:
-            result (list): 
+            result (list): ChatGPTの出力を分割して格納したリスト.len(result)=3
+            error_count (int): フォーマットに従わない出力が行われた回数
         Returns:
-            bool: returnは正常/異常(0/1)
+            bool: returnは正常/異常(1/0)
         Raises:
-            HTTP_502_BAD_GATEWAY: ChatGPTが LUK|NAME|TEXT のフォーマットに従っていない.
+            HTTP_408_REQUEST_TIMEOUT: ChatGPTが LUK(int)|NAME(str)|TEXT(str) のフォーマットに従っていない.
     """
     try:
 
@@ -19,15 +21,44 @@ def validation_element_car_data(result:list,error_count:int):
         result[0] = int(result[0])
 
         assert len(result) == 3 
-        return False
+        return True
 
     except:
+        print(result)
         if error_count >= 4:
-            print(result)
             raise HTTPException(
                 status_code=status.HTTP_408_REQUEST_TIMEOUT,
                 detail="ChatGPT output does not follow the format",
             )
         else:
-            return True
+            return False
+
+tokenizer = GPT2Tokenizer.from_pretrained("gpt2")
+
+def validate_token_count(text:str,token_num:int) -> bool:
+    
+    """
+        ユーザーの入力トークン数が上限を超えていないかのチェック
+        上限を超えるとエラーを出力
+        Args:
+            text (str): ユーザーの入力
+            token_num (int): トークンの上限
+        Returns:
+            bool: returnは正常/異常(1/0)
+        Raises:
+            HTTP_400_BAD_REQUEST: ユーザーの入力がトークンの上限を超えた.
+    """
+
+    tokens = tokenizer.tokenize(text)
+    if len(tokens) <= token_num:
+        return True
+    else:
+        print("text:"+text)
+        print("token_num:"+str(token_num))
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Number of tokens has exceeded the input limit.",
+        )
+
+
 


### PR DESCRIPTION
…
## 目的
validate関数の追加

## 概要
validateの戻り値を正常/異常(1/0)で統一
ユーザーの入力にトークン数の上限を設けるvalidate_token_countを実装
rembgが重すぎてInstallできなかった為,rembgの処理を取り除いたtest用の関数を実装.本番環境で消す予定.

## 確認項目

- [x] mainでtest用のAPIに切り替え
- [x] api/chat_gpt/car_data.py 19行目
の値をを30から5にする.
この値はユーザーの入力トークン数の上限である.(文字数ではなく英語に直した際の語数であることに注意)
- [x] 英語にしたら5ワード以上になりそうな文を{player}/car_dataに入力し,400エラーが発生することを確認
## 不安・相談
