### PR TITLE
車の作成結果画面を作成

### DIFF
--- a/view/src/app/create/page.tsx
+++ b/view/src/app/create/page.tsx
@@ -96,7 +96,7 @@ export default function Home() {
     const blob = await toBlob(dataBase64);
     if (blob) {
       const url = URL.createObjectURL(blob);
-      localStorage.setItem("UserCar", url);
+      localStorage.setItem(PLAYER_CAR_IMAGE, url);
     }
   };
 

--- a/view/src/app/create/result/page.tsx
+++ b/view/src/app/create/result/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+
 import Image from "next/image";
 import { Card } from "@/components/ui/card";
 import {
@@ -18,17 +19,18 @@ export default function Home() {
     return (
       <main>
         <div className="flex flex-wrap justigy-around items-center h-screen bg-basecolor">
-          <div className="h-4/5 w-1/2 p-4">
-            <div className="flex flex-col justify-around items-center h-full w-full bg-primarycolor rounded-xl border-4 border-accentcolor">
-              <Card className="text-3xl text-center w-11/12 border-4 border-basecolor p-8">
-                <p>俺の名前は{localStorage.getItem(PLAYER_CAR_NAME)}!!</p>
-                <p>
-                  {PLAYER_CAR_FORTUNE[localStorage.getItem(PLAYER_CAR_LUCK)]}
-                </p>
+          <div className="flex h-full w-1/2 p-4 flex-col justify-around items-center">
+            <div className="text-3xl tracking-wider text-center w-11/12 p-4 items-center bg-secondarycolor text-basecolor rounded-xl border-4 border-accentcolor">
+              <div className="p-4 text-left">
                 <p>{localStorage.getItem(PLAYER_CAR_INSTRUCTION)}</p>
-              </Card>
+              </div>
             </div>
+            <Card className="text-4xl tracking-wider text-center w-11/12 border-4 border-accentcolor p-8">
+              <p>俺は、{localStorage.getItem(PLAYER_CAR_NAME)}</p>
+              <p>今日は、{PLAYER_CAR_FORTUNE[6]}</p>
+            </Card>
           </div>
+
           <div className="h-4/5 w-1/2 p-4">
             <div className="flex flex-col justify-around items-center h-full w-full bg-primarycolor rounded-xl border-4 border-accentcolor">
               <Image

--- a/view/src/app/create/result/page.tsx
+++ b/view/src/app/create/result/page.tsx
@@ -1,15 +1,49 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import Image from "next/image";
+import { Card } from "@/components/ui/card";
+import {
+  PLAYER_CAR_IMAGE,
+  PLAYER_CAR_NAME,
+  PLAYER_CAR_LUCK,
+  PLAYER_CAR_INSTRUCTION,
+  PLAYER_CAR_FORTUNE,
+} from "@/lib/const";
 
 export default function Home() {
-  const image = localStorage.getItem("UserCar");
+  const image = localStorage.getItem(PLAYER_CAR_IMAGE);
   const router = useRouter();
   if (image) {
     return (
-      <div>
-        <img src={image}></img>
-      </div>
+      <main>
+        <div className="flex flex-wrap justigy-around items-center h-screen bg-basecolor">
+          <div className="h-4/5 w-1/2 p-4">
+            <div className="flex flex-col justify-around items-center h-full w-full bg-primarycolor rounded-xl border-4 border-accentcolor">
+              <Card className="text-3xl text-center w-11/12 border-4 border-basecolor p-8">
+                <p>俺の名前は{localStorage.getItem(PLAYER_CAR_NAME)}!!</p>
+                <p>
+                  {PLAYER_CAR_FORTUNE[localStorage.getItem(PLAYER_CAR_LUCK)]}
+                </p>
+                <p>{localStorage.getItem(PLAYER_CAR_INSTRUCTION)}</p>
+              </Card>
+            </div>
+          </div>
+          <div className="h-4/5 w-1/2 p-4">
+            <div className="flex flex-col justify-around items-center h-full w-full bg-primarycolor rounded-xl border-4 border-accentcolor">
+              <Image
+                src={image}
+                width={700}
+                height={700}
+                alt="player_car_image"
+              />
+            </div>
+          </div>
+        </div>
+      </main>
+      // <div>
+      //   <img src={image}></img>
+      // </div>
     );
   } else {
     router.push("/create");

--- a/view/src/lib/const.ts
+++ b/view/src/lib/const.ts
@@ -3,6 +3,16 @@ export const PLAYER_CAR_IMAGE = "player_car_image";
 export const PLAYER_CAR_NAME = "player_car_name";
 export const PLAYER_CAR_LUCK = "player_car_luck";
 export const PLAYER_CAR_INSTRUCTION = "player_car_instruction";
+export const PLAYER_CAR_FORTUNE = 
+    {   
+        0: "最悪の運勢だぜ！",
+        1: "不運な日だな...",
+        2: "まあまあの運勢だぜ！",
+        3: "普通の日だな...",
+        4: "結構いい日だぜ！",
+        5: "いい日だな！",
+        6: "最高の運勢だぜ！"
+    }
 // Enemy Car Constants
 export const ENEMY_CAR_IMAGE = "enemy_car_image";
 export const ENEMY_CAR_NAME = "enemy_car_name";

--- a/view/src/lib/const.ts
+++ b/view/src/lib/const.ts
@@ -3,16 +3,14 @@ export const PLAYER_CAR_IMAGE = "player_car_image";
 export const PLAYER_CAR_NAME = "player_car_name";
 export const PLAYER_CAR_LUCK = "player_car_luck";
 export const PLAYER_CAR_INSTRUCTION = "player_car_instruction";
-export const PLAYER_CAR_FORTUNE = 
-    {   
-        0: "最悪の運勢だぜ！",
-        1: "不運な日だな...",
-        2: "まあまあの運勢だぜ！",
-        3: "普通の日だな...",
-        4: "結構いい日だぜ！",
-        5: "いい日だな！",
-        6: "最高の運勢だぜ！"
-    }
+export const PLAYER_CAR_FORTUNE = {
+  1: "何をやってもうまくいかない気がする...",
+  2: "心が落ち着かないな...",
+  3: "少し疲れ気味だ...",
+  4: "晴れやかな気分だ!",
+  5: "やる気満々だ!",
+  6: "負ける気がしない!",
+};
 // Enemy Car Constants
 export const ENEMY_CAR_IMAGE = "enemy_car_image";
 export const ENEMY_CAR_NAME = "enemy_car_name";


### PR DESCRIPTION
## 目的
車の作成結果画面を作成
## 概要
車の作成後、作成された車が表示されるようにした。
`1024x1024`を想定して作っているので、今本番用APIを使うと表示がバグる
## 確認項目

- [ ] テスト用APIで車の作成ボタンを押して作成結果が表示されることを確認する
<img width="1437" alt="image" src="https://github.com/nose221834/ChatGP/assets/52813844/3381ce65-e4fe-45f0-8274-6203cddaf705">

## 不安・相談
