### PR TITLE
luckがintに直せていなかったため,修正

### DIFF
--- a/api/api_test/test_car_data.py
+++ b/api/api_test/test_car_data.py
@@ -15,7 +15,7 @@ def test_make_car(player: str,text: str, api_key: str = Security(validate_api_ke
     with open("api_test/test_media/removed_gpt_car.bin","rb") as f:
         binary_data = f.read()
     name = 'Feline Fury'
-    luk = '4'
+    luk = 4
     text_car_status = '洗練されたエクステリア、居心地の良いインテリア、そしてエンターテイメント用の内蔵レーザーポインターなどの先進機能で、この車は猫愛好家のために完璧にデザインされている。すべてのドライブがキャットウォークのように感じられること請け合いだ。ニャーベラス！'
     
     return {"player_car_image": b64encode(binary_data),"player_car_name": name,"player_car_luck": luk,"player_car_instruction": text_car_status}

--- a/api/chat_gpt/chat_gpt_validator.py
+++ b/api/chat_gpt/chat_gpt_validator.py
@@ -30,7 +30,7 @@ def validate_chat_gpt_output_count(result:list,item_count_in_format:int,error_co
         else:
             return False
 
-def validate_luk_is_number(result:list,error_count:int) -> bool:
+def validate_luk_is_number(output_chatgpt:int,error_count:int) -> bool:
 
     """
         ChatGPTが出力した車のlukが数字になっているか確認
@@ -45,12 +45,14 @@ def validate_luk_is_number(result:list,error_count:int) -> bool:
     """
     try:
         #lukが数値になっているか？　ChatGPTの出力(str)をintに変換
-        result[0] = int(result[2])
+
+        
+        assert isinstance(output_chatgpt,int)
         
         return True
 
     except:
-        print(result)
+        print(output_chatgpt)
         if error_count >= 4:
             raise HTTPException(
                 status_code=status.HTTP_408_REQUEST_TIMEOUT,

--- a/api/chat_gpt/status_generation.py
+++ b/api/chat_gpt/status_generation.py
@@ -28,7 +28,7 @@ async def status_generate_chatgpt(user_input:str):
     system_prompt,user_prompt = shaping_prompts_status_generate(user_input)
 
     while(not(validate_chat_gpt_output_count(text_split,item_count_in_format,number_of_generation) 
-            and validate_luk_is_number(text_split,number_of_generation))):
+            and validate_luk_is_number(text_split[2],number_of_generation))):
 
         res = client.chat.completions.create(
         model="gpt-3.5-turbo",
@@ -45,7 +45,7 @@ async def status_generate_chatgpt(user_input:str):
         #text_split=[0,1,2,3]
         number_of_generation += 1
 
-    luk = text_split[2].replace('\n','')
+    luk = int(text_split[2])
     name = text_split[4].replace('\n','')
     text_car_status = text_split[6].replace('\n','')
     return [luk,name,text_car_status]

--- a/api/database/database_routes.py
+++ b/api/database/database_routes.py
@@ -38,11 +38,12 @@ def get_enemy_car( api_key: str = Security(validate_api_key)):
     #データベースから敵の車データを取得
     [list_car_data] = get_data(db,table,key,car_id)
 
+    enemy_car_luck = int(list_car_data[3])
     #pathから画像を取得
     img = Image.open(list_car_data[1])
 
     #バイナリーに変換
     img_binary = img.tobytes()
 
-    return {"enemy_car_image": b64encode(img_binary),"enemy_car_name":list_car_data[2],"enemy_car_luck": list_car_data[3],"enemy_car_introduction": list_car_data[4]}
+    return {"enemy_car_image": b64encode(img_binary),"enemy_car_name":list_car_data[2],"enemy_car_luck": enemy_car_luck,"enemy_car_introduction": list_car_data[4]}
 


### PR DESCRIPTION
## 目的
luckがintに直せていなかったため,修正

## 概要
luckがintに直せていなかったため,修正
validate_luk_is_numberの中で浅いコピーを利用してリストを変更していたが,可読性が悪く,汎用性が悪いため,やめました.

## 確認項目
以下のAPIでlukが数値になっていることを確認
- [ ] テスト用APIの{player}/car/data,
- [ ] no_rembg.pyとcar_data.pyの2つの本番用API
- [ ] data/enemy

## 不安・相談
