### PR TITLE
[Server Action]ユーザーの入力に応じてRace結果を制御するAPIを叩くServer Actionを作成

### DIFF
--- a/view/src/app/create/result/page.tsx
+++ b/view/src/app/create/result/page.tsx
@@ -68,8 +68,9 @@ export default function Home() {
             <div className="flex justify-end p-4 w-full">
               <Button className="w-44 h-16 text-3xl bg-accentcolor border-basecolor hover:bg-primarycolor border-4"
                 onClick={() => {
-                  alert('Button clicked');
-                }}>Next</Button>
+                  router.push("/race");
+                }}>Next
+              </Button>
             </div>
           </Card>
         </div>

--- a/view/src/app/create/result/page.tsx
+++ b/view/src/app/create/result/page.tsx
@@ -39,6 +39,11 @@ export default function Home() {
   if(!carImage) router.push("/create");
   if(!carName) router.push("/create");
   if(!carFortune) router.push("/create");
+
+  const moveToRace = () => {
+    router.push("/race");
+  }
+
   return (
     <main>
       <div className="flex flex-wrap justigy-around items-center h-screen bg-basecolor">
@@ -67,9 +72,8 @@ export default function Home() {
             </div>
             <div className="flex justify-end p-4 w-full">
               <Button className="w-44 h-16 text-3xl bg-accentcolor border-basecolor hover:bg-primarycolor border-4"
-                onClick={() => {
-                  router.push("/race");
-                }}>Next
+                onClick={moveToRace}>
+                  Next
               </Button>
             </div>
           </Card>

--- a/view/src/app/race/page.tsx
+++ b/view/src/app/race/page.tsx
@@ -5,6 +5,8 @@ import { Interactive } from "./Interactive";
 import { Progress } from "./Progress";
 import { useRouter } from "next/navigation";
 import { SubmitProps, InteProps, ResponceProps, ProgProps } from "./type";
+import { RaceData } from "@/app/race/type";
+import { getRaceDataFromGpt } from "@/lib/race/action";
 
 export default function Home() {
   const router = useRouter();
@@ -13,10 +15,32 @@ export default function Home() {
   // InteractiveとProgressを切り替えるState
   const [responce, setResponce] = useState<boolean>(false);
 
-  function onSubmit(data: SubmitProps) {
+  const testGetRaceInfoFromGpt = async (event: string) => {
+    // Sample RaceData
+    const sampleRaceData: RaceData = {
+      "first_car_name": "string",
+      "second_car_name": "string",
+      "third_car_name": "string",
+      "fourth_car_name": "string",
+      "player_car_name": "string",
+      "first_car_introduction": "string",
+      "second_car_introduction": "string",
+      "third_car_introduction": "string",
+      "fourth_car_introduction": "string",
+      "event": event
+    };
+    console.log("sampleRaceData", JSON.stringify(sampleRaceData));
+    const responseJson = await getRaceDataFromGpt(sampleRaceData);
+    console.log("responseJson:", responseJson);
+    return true;
+  };
+
+  async function onSubmit(data: SubmitProps) {
     if (scene + 1 >= 3) {
+      console.log("data:", data.text)
       router.push("/race/ending");
     } else {
+      testGetRaceInfoFromGpt(data.text);
       setResponce(true);
     }
   }

--- a/view/src/app/race/type.ts
+++ b/view/src/app/race/type.ts
@@ -1,5 +1,22 @@
 import { SubmitHandler } from "react-hook-form";
-
+import { GENERATED_TEXT,
+        FIRST_PLACE,
+        SECOND_PLACE,
+        THIRD_PLACE,
+        FOURTH_PLACE,
+        FIRST_CAR_NAME,
+        SECOND_CAR_NAME,
+        THIRD_CAR_NAME,
+        FOURTH_CAR_NAME,
+        FIRST_CAR_INSTRUCTION,
+        SECOND_CAR_INSTRUCTION,
+        THIRD_CAR_INSTRUCTION,
+        FOURTH_CAR_INSTRUCTION,
+        RACE_EVENT,
+        PLAYER_CAR_INSTRUCTION,
+        PLAYER_LUCK,
+        PLAYER_CAR_NAME
+      } from "@/lib/const";
 
 export type SubmitProps = {
   text: string;
@@ -20,4 +37,39 @@ export type ProgProps = {
   order: number;
   scene: number;
   click: () => void;
+};
+
+export type RaceInfoRes = {
+  [GENERATED_TEXT]: string;
+  [FIRST_PLACE]: string;
+  [SECOND_PLACE]: string;
+  [THIRD_PLACE]: string;
+  [FOURTH_PLACE]: string;
+};
+
+export type RaceData = {
+  [FIRST_CAR_NAME]: string;
+  [SECOND_CAR_NAME]: string;
+  [THIRD_CAR_NAME]: string;
+  [FOURTH_CAR_NAME]: string;
+  [PLAYER_CAR_NAME]: string;
+  [FIRST_CAR_INSTRUCTION]: string;
+  [SECOND_CAR_INSTRUCTION]: string;
+  [THIRD_CAR_INSTRUCTION]: string;
+  [FOURTH_CAR_INSTRUCTION]: string;
+  [RACE_EVENT]: string;
+};
+
+export type RaceEndData = {
+  [FIRST_CAR_NAME]: string;
+  [SECOND_CAR_NAME]: string;
+  [THIRD_CAR_NAME]: string;
+  [FOURTH_CAR_NAME]: string;
+  [FIRST_CAR_INSTRUCTION]: string;
+  [SECOND_CAR_INSTRUCTION]: string;
+  [THIRD_CAR_INSTRUCTION]: string;
+  [FOURTH_CAR_INSTRUCTION]: string;
+  [RACE_EVENT]: string;
+  [PLAYER_CAR_INSTRUCTION]: string;
+  [PLAYER_LUCK]: number;
 };

--- a/view/src/lib/const.ts
+++ b/view/src/lib/const.ts
@@ -17,3 +17,23 @@ export const ENEMY_CAR_IMAGE = "enemy_car_image";
 export const ENEMY_CAR_NAME = "enemy_car_name";
 export const ENEMY_CAR_LUCK = "enemy_car_luck";
 export const ENEMY_CAR_INSTRUCTION = "enemy_car_instruction";
+// Race Info Constants
+export const GENERATED_TEXT = "generated_text";
+
+export const FIRST_PLACE = "first_place";
+export const SECOND_PLACE = "second_place";
+export const THIRD_PLACE = "third_place";
+export const FOURTH_PLACE = "fourth_prace";
+
+export const FIRST_CAR_NAME = "first_car_name";
+export const SECOND_CAR_NAME = "second_car_name";
+export const THIRD_CAR_NAME = "third_car_name";
+export const FOURTH_CAR_NAME = "fourth_car_name";
+
+export const FIRST_CAR_INSTRUCTION = "first_car_introduction";
+export const SECOND_CAR_INSTRUCTION = "second_car_introduction";
+export const THIRD_CAR_INSTRUCTION = "third_car_introduction";
+export const FOURTH_CAR_INSTRUCTION = "fourth_car_introduction";
+
+export const RACE_EVENT = "event";
+export const PLAYER_LUCK = "player_luck";

--- a/view/src/lib/race/action.ts
+++ b/view/src/lib/race/action.ts
@@ -1,0 +1,32 @@
+"use server";
+
+import { RaceData, RaceEndData, RaceInfoRes } from '@/app/race/type'
+
+const apiId = process.env.NEXT_PUBLIC_API_ACCESS_ID;
+const apiKey = process.env.NEXT_PUBLIC_API_ACCESS_KEY;
+const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+
+// レース中のインタラクティブな入出力に関するアクションを定義する
+export const getRaceDataFromGpt = async (data: RaceData) =>{
+    if (!apiId || !apiKey || !apiUrl) return false;
+    const endPoint = `${apiUrl}/race/middle_part`;
+    console.log("Endpoint:", endPoint);
+    const responseJson: RaceInfoRes = await fetch(endPoint, {
+      method: "POST",
+      headers: {
+        'Content-Type': 'application/json',
+        [apiId]: apiKey,
+      },
+      body: JSON.stringify(data),
+    })
+      .then((res) => res.json())
+      .catch((err) => {
+        console.error("Error:", err);
+        return false;
+      });
+    return responseJson;
+}
+
+export const getEndDataFromGpt = async (data: RaceEndData) =>{
+
+}


### PR DESCRIPTION
## 目的
[Server Action]ユーザーの入力に応じてRace結果を制御するAPIを叩くServer Actionを作成
## 概要
- 車の作成結果画面からRace画面に遷移するように修正
- ユーザーがイベントを入力するとAPIを叩けるようにした
## 確認項目

- [x] レース画面までの画面遷移ができることの確認
1. `localhost:3000`にアクセス
2. 車を作成、`localhsot:3000:create/result`に飛ばされることを確認
3. Next Buttonを押すとRace画面に飛ばされることを確認
- [x] Race画面で入力し、送信してしばらくするとブラウザのデバッグ画面に`/race/middle_part`からResponseが返ってくることを確認

## 不安・相談
