### PR TITLE
車の画像を反転する関数の追加

### DIFF
--- a/api/api_test/test_car_data.py
+++ b/api/api_test/test_car_data.py
@@ -6,6 +6,7 @@ from transformers import GPT2Tokenizer
 from base64 import b64encode
 from config import PlayerCarKeys
 from models import InputTextModel
+from utils.revere_image import reverse_image
 
 tokenizer = GPT2Tokenizer.from_pretrained("gpt2")
 router = APIRouter()
@@ -16,6 +17,7 @@ def test_make_car(input_text_model:InputTextModel = Depends(),api_key: str = Sec
 
     with open("api_test/test_media/removed_gpt_car.bin","rb") as f:
         binary_data = f.read()
+    binary_data = reverse_image(binary_data)
     name = 'Feline Fury'
     luk = 4
     text_car_status = '洗練されたエクステリア、居心地の良いインテリア、そしてエンターテイメント用の内蔵レーザーポインターなどの先進機能で、この車は猫愛好家のために完璧にデザインされている。すべてのドライブがキャットウォークのように感じられること請け合いだ。ニャーベラス！'

--- a/api/chat_gpt/image_generation.py
+++ b/api/chat_gpt/image_generation.py
@@ -2,6 +2,7 @@ from openai import OpenAI
 import requests
 from base64 import b64encode
 from utils.remove_bg import remove_background
+from utils.revere_image import reverse_image
 
 client = OpenAI()
 
@@ -47,9 +48,11 @@ async def image_generate_chatgpt(text:str):
 
     # URLから画像(バイナリ)を取得
     car_img_binary: bytes = requests.get(image_url).content
+
+    remove_bg_img: bytes = remove_background(car_img_binary) # 画像の背景を透過する
+
+    reverse_img: bytes = reverse_img(remove_bg_img) # 画像を反転する
     
-    binary_image: bytes = remove_background(car_img_binary) # 画像の背景を透過する
-    
-    return b64encode(binary_image) # 画像(バイナリ)をbase64に変換して返す
+    return b64encode(reverse_image) # 画像(バイナリ)をbase64に変換して返す
 
 

--- a/api/utils/revere_image.py
+++ b/api/utils/revere_image.py
@@ -1,0 +1,21 @@
+from PIL import Image
+from io import BytesIO
+
+def reverse_image(image: bytes | Image.Image):
+    """
+        画像を反転する
+        Args:
+            image (bytes or PIL.Image): 画像
+        Returns:
+            reversed_image: 反転した画像(バイナリ)
+        Raises:
+            TypeError: imageがbytesまたはPIL.Imageでない場合
+    """
+    if isinstance(image, bytes):
+        image = Image.open(BytesIO(image)) # 画像(バイナリ)をImageに変換
+    if not isinstance(image, Image.Image):
+        raise TypeError("image must be bytes or PIL.Image")
+    reversed_image = image.transpose(Image.FLIP_LEFT_RIGHT) # 画像を反転
+    buffered = BytesIO()
+    reversed_image.save(buffered, format="PNG")
+    return buffered.getvalue() # 画像(バイナリ)を取得


### PR DESCRIPTION
## 目的
車の画像を反転する関数の追加
## 概要
車の画像を反転する関数を追加して、本番用APIとテスト用APIに適用した
## 確認項目

- [ ] `localhost:9004/create`にアクセスして以下の
![image](https://github.com/nose221834/ChatGP/assets/52813844/cfd37116-3cf3-468d-b45f-17f5d495b5fa)

## 不安・相談
