### PR TITLE
ReactFookFormがreturnの後ろに来ないように環境変数をチェックする処理の位置を変更した

### DIFF
--- a/view/src/app/create/page.tsx
+++ b/view/src/app/create/page.tsx
@@ -23,14 +23,6 @@ export default function Home() {
   const apiKey = process.env.NEXT_PUBLIC_API_ACCESS_KEY;
   const apiUrl = process.env.NEXT_PUBLIC_API_URL;
 
-  if (!apiId || !apiKey || !apiUrl) {
-    return (
-      <div>
-        <h1>環境変数がありません</h1>
-      </div>
-    );
-  }
-
   const {
     register,
     handleSubmit,
@@ -40,6 +32,15 @@ export default function Home() {
       text: "例：宇宙船に乗ってる猫",
     },
   });
+  
+  if (!apiId || !apiKey || !apiUrl) {
+    return (
+      <div>
+        <h1>環境変数がありません</h1>
+      </div>
+    );
+  }
+
 
   const onSubmit: SubmitHandler<PlayerCarInput> = async (data: PlayerCarInput) => {
     try {


### PR DESCRIPTION
## 目的
ReactFookFormがreturnの後ろに来ないように環境変数をチェックする処理の位置を変更した
## 概要
ReactFookFormがreturnの後ろに来ないように環境変数をチェックする処理の位置を変更した
## 確認項目

- [x] ブラウザのデバッグ画面でエラーやウォーニングが発生しないこと

## 不安・相談
