### PR TITLE
[RequestBody]Request Bodyを生成する関数を追加

### DIFF
--- a/view/src/app/race/page.tsx
+++ b/view/src/app/race/page.tsx
@@ -11,44 +11,9 @@ import {
   RACE_EVENT,
   RACE_RESPONSE_DATA,
 } from "@/lib/const";
-import { generateRaceRequestBody } from "@/lib/race/generateRequestBody";
+import { generateRaceRequestBody, generateRaceEndRequestBody } from "@/lib/race/generateRequestBody";
 
 export default function Home() {
-  // Sample RaceData
-  const sampleRaceData: RaceData = {
-    first_car_name: "string",
-    second_car_name: "string",
-    third_car_name: "string",
-    fourth_car_name: "string",
-    player_car_name: "string",
-    first_car_instruction: "string",
-    second_car_instruction: "string",
-    third_car_instruction: "string",
-    fourth_car_instruction: "string",
-    event: "event",
-  };
-
-  const testGetEndDataFromGpt = async (event: string) => {
-    // Sample RaceData
-    const sampleRaceData: RaceEndData = {
-      "first_car_name": "string",
-      "second_car_name": "string",
-      "third_car_name": "string",
-      "fourth_car_name": "string",
-      "player_car_name": "string",
-      "first_car_instruction": "string",
-      "second_car_instruction": "string",
-      "third_car_instruction": "string",
-      "fourth_car_instruction": "string",
-      "event": event,
-      "player_car_instruction": "string",
-      "player_luck": 1,
-    };
-    console.log("sampleRaceData", JSON.stringify(sampleRaceData));
-    const responseJson = await getEndDataFromGpt(sampleRaceData);
-    console.log("responseJson:", responseJson);
-    return true;
-  };
 
   const router = useRouter();
   // 場面を切り替えるためのState
@@ -59,18 +24,13 @@ export default function Home() {
   async function onSubmit(data: SubmitProps) {
     if (scene + 1 >= 3) {
       console.log("scene + 1 >= 3");
-      testGetEndDataFromGpt(data.event);
-      const previousResponce = localStorage.getItem(RACE_RESPONSE_DATA);
-      if (previousResponce) {
-        const previousJson = JSON.parse(previousResponce) as RaceData;
-        const sendJson = {
-          ...previousJson,
-          [RACE_EVENT]: data.event,
-        };
-        // const responseJson = await getEndDataFromGpt(sendJson);
-        // localStorage.setItem(RACE_RESPONSE_DATA, JSON.stringify(responseJson));
-        router.push("/race/ending");
-      }
+      const requestBody: RaceEndData = generateRaceEndRequestBody(data.event);
+      const responseJson = await getEndDataFromGpt(requestBody);
+      console.log("responseJson:", responseJson);
+      if (!responseJson) return <div>Error</div>;
+      localStorage.setItem(RACE_RESPONSE_DATA, JSON.stringify(responseJson));
+      router.push("/race/ending");
+      // }
     } else {
       console.log("router.push()");
       const requestBody: RaceData = generateRaceRequestBody(data.event);

--- a/view/src/lib/race/action.ts
+++ b/view/src/lib/race/action.ts
@@ -7,27 +7,29 @@ const apiKey = process.env.NEXT_PUBLIC_API_ACCESS_KEY;
 const apiUrl = process.env.NEXT_PUBLIC_API_URL;
 
 // レース中のインタラクティブな入出力に関するアクションを定義する
-export const getRaceDataFromGpt = async (data: RaceData) =>{
-    if (!apiId || !apiKey || !apiUrl) return false;
-    const endPoint = `${apiUrl}/race/middle_part`;
-    console.log("Endpoint:", endPoint);
-    const responseJson: RaceInfoRes = await fetch(endPoint, {
-      method: "POST",
-      headers: {
-        'Content-Type': 'application/json',
-        [apiId]: apiKey,
-      },
-      body: JSON.stringify(data),
-    })
-      .then((res) => res.json())
-      .catch((err) => {
-        console.error("Error:", err);
-        return false;
-      });
-    return responseJson;
+export const getRaceDataFromGpt = async (data: RaceData) => {
+  if (!apiId || !apiKey || !apiUrl) return false;
+  const endPoint = `${apiUrl}/race/middle_part`;
+  console.log("Request Body:", data);
+  console.log("Endpoint:", endPoint);
+  const responseJson: RaceInfoRes = await fetch(endPoint, {
+    method: "POST",
+    headers: {
+      'Content-Type': 'application/json',
+      [apiId]: apiKey,
+    },
+    body: JSON.stringify(data),
+  })
+    .then((res) => res.json())
+    .catch((err) => {
+      console.error("Error:", err);
+      return false;
+    });
+  console.log("responseJson:", responseJson);
+  return responseJson;
 }
 
-export const getEndDataFromGpt = async (data: RaceEndData) =>{
+export const getEndDataFromGpt = async (data: RaceEndData) => {
   if (!apiId || !apiKey || !apiUrl) return false;
   const endPoint = `${apiUrl}/race/ending`;
   console.log("Endpoint:", endPoint);

--- a/view/src/lib/race/generateRequestBody.ts
+++ b/view/src/lib/race/generateRequestBody.ts
@@ -1,5 +1,6 @@
-import { RaceInfoRes, RaceData } from "@/app/race/type";
-import { RACE_RESPONSE_DATA,
+import { RaceInfoRes, RaceData, RaceEndData } from "@/app/race/type";
+import {
+    RACE_RESPONSE_DATA,
     GENERATED_TEXT,
     FIRST_PLACE,
     SECOND_PLACE,
@@ -9,6 +10,7 @@ import { RACE_RESPONSE_DATA,
     PLAYER_CAR_NAME,
     ENEMY_CAR,
     ENEMY_CAR_NAME,
+    PLAYER_CAR_LUCK,
     PLAYER_CAR_INSTRUCTION,
     ENEMY_CAR_INSTRUCTION,
     FIRST_CAR_NAME,
@@ -20,7 +22,24 @@ import { RACE_RESPONSE_DATA,
     THIRD_CAR_INSTRUCTION,
     FOURTH_CAR_INSTRUCTION,
     RACE_EVENT,
-    } from "@/lib/const";
+    PLAYER_LUCK
+} from "@/lib/const";
+
+export const generateRaceEndRequestBody = (event: string) => {
+    const raceRequestBody: RaceData = generateRaceRequestBody(event);
+    const playerCar = localStorage.getItem(PLAYER_CAR);
+    if (playerCar === null) {
+        throw new Error("Player Car Data is not found.");
+    }
+    const playerCarInstruction: string = JSON.parse(playerCar)[PLAYER_CAR_INSTRUCTION];
+    const playerCarLuck: number = JSON.parse(playerCar)[PLAYER_CAR_LUCK];
+    const requestBody: RaceEndData = {
+        ...raceRequestBody,
+        [PLAYER_CAR_INSTRUCTION]: playerCarInstruction,
+        [PLAYER_LUCK]: playerCarLuck
+    };
+    return requestBody;
+};
 
 export const generateRaceRequestBody = (event: string) => {
     // localStorageに入っているResponseJson:RACE_INFO_RESPONSEを取得
@@ -32,10 +51,10 @@ export const generateRaceRequestBody = (event: string) => {
     const fourthPlace = responseJson[FOURTH_PLACE];
     // PLAYER_CAR_NAMEを取得する
     const playerCar = localStorage.getItem(PLAYER_CAR);
-    if(playerCar === null) {
+    if (playerCar === null) {
         throw new Error("Player Car Data is not found.");
     }
-    const playerCarName:string = JSON.parse(playerCar)[PLAYER_CAR_NAME];
+    const playerCarName: string = JSON.parse(playerCar)[PLAYER_CAR_NAME];
     // CAR_NAMEからCAR_INSTRUCTIONを取得する(関数)
     const firstCarInstruction = getCarInstruction(firstPlace);
     const secondCarInstruction = getCarInstruction(secondPlace);
@@ -58,15 +77,15 @@ export const generateRaceRequestBody = (event: string) => {
 };
 
 const getCarInstruction = (carName: string) => {
-    // PLAYER_CARおよびENEMY_CARのINSTRUCTIONを参照し、一致したら返却
-    if(carName === localStorage.getItem(PLAYER_CAR_NAME)) {
-        return localStorage.getItem(PLAYER_CAR_INSTRUCTION);
-    }
     const playerCar = localStorage.getItem(PLAYER_CAR);
     if (playerCar === null) {
         throw new Error("Player Car Data is not found.");
     }
     const playerCarName: string = JSON.parse(playerCar)[PLAYER_CAR_NAME];
+    // PLAYER_CARおよびENEMY_CARのINSTRUCTIONを参照し、一致したら返却
+    if (carName === playerCarName) {
+        return JSON.parse(playerCar)[PLAYER_CAR_INSTRUCTION];
+    }
 
     const enemyCar0 = localStorage.getItem(ENEMY_CAR + '_0');
     const enemyCar1 = localStorage.getItem(ENEMY_CAR + '_1');
@@ -77,13 +96,13 @@ const getCarInstruction = (carName: string) => {
     const enemyCarName0: string = JSON.parse(enemyCar0)[ENEMY_CAR_NAME];
     const enemyCarName1: string = JSON.parse(enemyCar1)[ENEMY_CAR_NAME];
     const enemyCarName2: string = JSON.parse(enemyCar2)[ENEMY_CAR_NAME];
-    if(carName === enemyCarName0) {
+    if (carName === enemyCarName0) {
         return JSON.parse(enemyCar0)[ENEMY_CAR_INSTRUCTION];
     }
-    if(carName === enemyCarName1) {
+    if (carName === enemyCarName1) {
         return JSON.parse(enemyCar1)[ENEMY_CAR_INSTRUCTION];
     }
-    if(carName === enemyCarName2) {
+    if (carName === enemyCarName2) {
         return JSON.parse(enemyCar2)[ENEMY_CAR_INSTRUCTION];
     }
 };
@@ -91,7 +110,7 @@ const getCarInstruction = (carName: string) => {
 const getResponseJson = () => {
     const responseJson = localStorage.getItem(RACE_RESPONSE_DATA);
     console.log("Get ResponseJson", responseJson);
-    if(responseJson === null) {
+    if (responseJson === null) {
         // 何もない場合は、仮のデータを返却する
         console.log("Generate Dummy ResponseJson");
         return generateDummyResponseJson();
@@ -109,10 +128,10 @@ const generateDummyResponseJson = () => {
     const enemyCar0 = localStorage.getItem(ENEMY_CAR + '_0');
     const enemyCar1 = localStorage.getItem(ENEMY_CAR + '_1');
     const enemyCar2 = localStorage.getItem(ENEMY_CAR + '_2');
-    if(playerCarName === null || enemyCar0 === null || enemyCar1 === null || enemyCar2 === null) {
+    if (playerCarName === null || enemyCar0 === null || enemyCar1 === null || enemyCar2 === null) {
         throw new Error("Player Car or Enemy Car Data is not found.");
     }
-    const enemyCarName0: string  = JSON.parse(enemyCar0)[ENEMY_CAR_NAME];
+    const enemyCarName0: string = JSON.parse(enemyCar0)[ENEMY_CAR_NAME];
     const enemyCarName1: string = JSON.parse(enemyCar1)[ENEMY_CAR_NAME];
     const enemyCarName2: string = JSON.parse(enemyCar2)[ENEMY_CAR_NAME];
     const dummyRaceInfoRes: RaceInfoRes = {


### PR DESCRIPTION
## 目的
[RequestBody]Request Bodyを生成する関数を追加
## 概要
- RaceおよびRace Endingで用いるRequest Bodyを作成する関数を追加した
- @nose221834 : 使い方は、`generateRaceEndRequestBody`か`generateRaceRequestBody`に`event`を投げるだけでRequest Bodyを返してくれる。最初の選択肢の時でも気にせずに使って大丈夫。

## 確認項目

- [ ] Race展開とEndingがブラウザのデバッグ画面に表示されることを確認する

## 不安・相談
- レスポンスが遅いから遷移をある程度こっちで制御しないと簡単にバグる
