### PR TITLE
[Bug Fix] Enemy Imageを反転,透過する処理を追加

### DIFF
--- a/api/chat_gpt/image_generation.py
+++ b/api/chat_gpt/image_generation.py
@@ -53,7 +53,7 @@ async def image_generate_chatgpt(text:str):
 
     # 画像を保存
     image_output_dir = Path("tmp/img")
-    image_output_dir.mkdir(exist_ok=True)
+    image_output_dir.mkdir(exist_ok=True, parents=True)
     image_file_name = "generated.png"
     save_image(car_img_binary, image_output_dir / image_file_name) # 生成された画像を確認するために用いる。本番では不要
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -6,5 +6,4 @@ deepl
 transformers
 rembg
 pillow
-flax
 

--- a/api/routes/database_routes.py
+++ b/api/routes/database_routes.py
@@ -6,7 +6,8 @@ from PIL import Image
 from base64 import b64encode
 import random
 from config import EnemyCarKeys
-from io import BytesIO
+from utils.remove_bg import remove_background
+from utils.reverse_image import reverse_image
 
 router = APIRouter()
 
@@ -41,14 +42,18 @@ def get_enemy_car( api_key: str = Security(validate_api_key)):
     #データベースから敵の車データを取得
     [list_car_data] = get_data(db,table,key,car_id)
     #pathから画像を取得
+    print("list_car_data", list_car_data[1])
     img = Image.open(list_car_data[1])
 
-    buffered = BytesIO()
-    img.save(buffered, format="PNG")
+    #背景を透過
+    rembg: bytes = remove_background(img)
+
+    #画像を逆転
+    reverse: bytes = reverse_image(rembg)
 
     luck = int(list_car_data[3])
 
-    return {EnemyCarKeys.image: b64encode(buffered.getvalue()),
+    return {EnemyCarKeys.image: b64encode(reverse),
             EnemyCarKeys.name:list_car_data[2],
             EnemyCarKeys.luck:luck,
             EnemyCarKeys.instruction: list_car_data[4]}

--- a/view/src/lib/race/getPlayerRank.ts
+++ b/view/src/lib/race/getPlayerRank.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { RaceInfoRes } from "@/app/race/type";
 import { generateDummyResponseJson } from "@/lib/race/generateRequestBody";
 import {


### PR DESCRIPTION
## 目的
Enemy Imageを反転,透過する処理を追加
## 概要
Enemy Imageを反転,透過する処理を追加
## 確認項目

- [x] Enemy Carの背景が投下され、右を向いていることを確認する。但し、最初の透過の際にモデルをダウンロードする必要があり、それの時間がかかるので連続でクリックするとバグる可能性がある。その場合は最初からやり直せばモデルがダウンロードされた状態でスタートするので正常に動作する

## 不安・相談
