### PR TITLE
database_operationを修正

### DIFF
--- a/api/api_test/test_database.py
+++ b/api/api_test/test_database.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Security, Form
 from utils.auth import validate_api_key
 from models import InputTextModel
-from database.database_operation import get_all_data_from_db,adding_data_to_db,deleting_db_data
+from database.database_operation import DatabaseOperator
 
 router = APIRouter()
 
@@ -17,8 +17,9 @@ def api_get_all_data_from_db(db:str,table:str,api_key: str = Security(validate_a
         Returns:  
             all_data_in_table (list): テーブル内の全データ
     """
+    db_operator = DatabaseOperator(db,table)
 
-    all_data_in_table = get_all_data_from_db(db,table)
+    all_data_in_table = db_operator.get_all_data_from_db()
     
     return {"all_data_in_table": all_data_in_table}
 
@@ -35,8 +36,9 @@ def api_adding_data_to_db(db:str,table:str,columns_list:list = Form(...),values_
         Returns:  
             None
     """
+    db_operator = DatabaseOperator(db,table)
 
-    adding_data_to_db(db,table,columns_list,values_list)
+    db_operator.adding_data_to_db(columns_list,values_list)
 
 @router.delete("/test/database/delete_data")
 def api_deleting_db_data(db:str,table:str,column:str,record:int | str,api_key: str = Security(validate_api_key)):
@@ -51,5 +53,6 @@ def api_deleting_db_data(db:str,table:str,column:str,record:int | str,api_key: s
         Returns:  
             None
     """
+    db_operator = DatabaseOperator(db,table)
 
-    deleting_db_data(db,table,column,record)
+    db_operator.deleting_db_data(column,record)

--- a/api/api_test/test_database.py
+++ b/api/api_test/test_database.py
@@ -1,12 +1,12 @@
-from fastapi import APIRouter, Security
+from fastapi import APIRouter, Security, Form
 from utils.auth import validate_api_key
 from models import InputTextModel
-from database.database_operation import get_all_data_from_db
+from database.database_operation import get_all_data_from_db,adding_data_to_db
 
 router = APIRouter()
 
 @router.get("/test/database/get_all")
-def translation_jp_to_en(db:str,table:str,api_key: str = Security(validate_api_key)):
+def api_get_all_data_from_db(db:str,table:str,api_key: str = Security(validate_api_key)):
     """
         指定したテーブルの全データをデータベースから取得する
 
@@ -21,3 +21,19 @@ def translation_jp_to_en(db:str,table:str,api_key: str = Security(validate_api_k
     all_data_in_table = get_all_data_from_db(db,table)
     
     return {"all_data_in_table": all_data_in_table}
+
+@router.post("/test/database/get_all")
+def api_adding_data_to_db(db:str,table:str,columns_list:list = Form(...),values_list:list = Form(...),api_key: str = Security(validate_api_key)):
+    """
+        データベースにデータを追加する
+
+        Args:
+            db (str): データベースのパス
+            table (str): 作業テーブルの名称
+            columns_list (list): テーブルが持つカラムのリスト
+            values_list (list): データベースに保存するデータのリスト,保存先はcolumns_listのインデックスと対応している
+        Returns:  
+            None
+    """
+
+    adding_data_to_db(db,table,columns_list,values_list)

--- a/api/api_test/test_database.py
+++ b/api/api_test/test_database.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter, Security
+from utils.auth import validate_api_key
+from models import InputTextModel
+from database.database_operation import get_all_data_from_db
+
+router = APIRouter()
+
+@router.get("/test/database/get_all")
+def translation_jp_to_en(db:str,table:str,api_key: str = Security(validate_api_key)):
+    """
+        指定したテーブルの全データをデータベースから取得する
+
+        Args:
+            db (str): データベースのパス
+            table (str): データベースの作業テーブル
+            
+        Returns:  
+            all_data_in_table (list): テーブル内の全データ
+    """
+
+    all_data_in_table = get_all_data_from_db(db,table)
+    
+    return {"all_data_in_table": all_data_in_table}

--- a/api/api_test/test_database.py
+++ b/api/api_test/test_database.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Security, Form
 from utils.auth import validate_api_key
 from models import InputTextModel
-from database.database_operation import get_all_data_from_db,adding_data_to_db
+from database.database_operation import get_all_data_from_db,adding_data_to_db,deleting_db_data
 
 router = APIRouter()
 
@@ -22,7 +22,7 @@ def api_get_all_data_from_db(db:str,table:str,api_key: str = Security(validate_a
     
     return {"all_data_in_table": all_data_in_table}
 
-@router.post("/test/database/get_all")
+@router.post("/test/database/add_data")
 def api_adding_data_to_db(db:str,table:str,columns_list:list = Form(...),values_list:list = Form(...),api_key: str = Security(validate_api_key)):
     """
         データベースにデータを追加する
@@ -37,3 +37,19 @@ def api_adding_data_to_db(db:str,table:str,columns_list:list = Form(...),values_
     """
 
     adding_data_to_db(db,table,columns_list,values_list)
+
+@router.delete("/test/database/delete_data")
+def api_deleting_db_data(db:str,table:str,column:str,record:int | str,api_key: str = Security(validate_api_key)):
+    """
+        データベースのデータを削除
+
+        Args:
+            db (str): データベースのパス
+            table (str): 作業テーブルの名称
+            column (str): 検索カラム
+            record (int | str): 削除するレコード
+        Returns:  
+            None
+    """
+
+    deleting_db_data(db,table,column,record)

--- a/api/database/database_operation.py
+++ b/api/database/database_operation.py
@@ -2,159 +2,201 @@ import sqlite3
 from validator.database_validator import connect_database,check_input_query
 from fastapi import  HTTPException,status
 
-def adding_data_to_db(db:str,table:str,columns_list:list,values_list:list) -> None:
-    """
-        データベースにデータを追加する
+class DatabaseOperator():
+
+    def __init__(self,db:str,table:str) -> None:
+        """
+        データベースを操作するクラス
 
         Args:
             db (str): データベースのパス
             table (str): 作業テーブルの名称
-            columns_list (list): テーブルが持つカラムのリスト
-            values_list (list): データベースに保存するデータのリスト,保存先はcolumns_listのインデックスと対応している
-        Returns:  
-            None
-    """
+        """
+        self.db = db
+        self.table = table
 
-    # クエリの作成
-    columns = ", ".join(columns_list)
-    values = ", ".join(values_list)
-    query = f"INSERT INTO {table} ({columns}) VALUES ({values})"
+        # tableの構造を出力
+        c = self._open_connection_with_db()
+        query = f"PRAGMA table_info({table});"
+        c.execute(query)
+        information = c.fetchall()
+        print(f"{table}の構造:{str(information)}")
+        self._close_connection_with_db()
 
-    # データベースに接続
-    conn = connect_database(db)
-    c = conn.cursor()
+    def _open_connection_with_db(self):
+        """
+            データベースに接続し,カーソルを作成
+
+            Args:
+                None
+            Returns:  
+                c : カーソル
+        """
+        # データベースに接続
+        self.conn = connect_database(self.db)
+        c = self.conn.cursor()
+
+        return c
     
-    # データベースに対してクエリを実行
-    c.execute(query)
+    def _close_connection_with_db(self):
+        """
+            データベースに接続を閉じる
 
-    # クエリによって実行された変更をデータベースにコミット
-    conn.commit()
+            Args:
+                None
+            Returns:  
+                None
+        """
 
-    # データベースとの接続を閉じる
-    conn.close()
+        self.conn.close()
 
-def deleting_db_data(db:str,table:str, column:str, record: int | str) -> None:
-    """
-        データベースのデータを削除
+    def adding_data_to_db(self,columns_list:list,values_list:list) -> None:
+        """
+            データベースにデータを追加する
 
-        Args:
-            db (str): データベースのパス
-            table (str): 作業テーブルの名称
-            column (str): 検索カラム
-            record (int | str): 削除するレコード
-        Returns:  
-            None
-    """
+            Args:
+                db (str): データベースのパス
+                table (str): 作業テーブルの名称
+                columns_list (list): テーブルが持つカラムのリスト
+                values_list (list): データベースに保存するデータのリスト,保存先はcolumns_listのインデックスと対応している
+            Returns:  
+                None
+        """
 
-    # データベースに接続
-    conn = connect_database(db)
-    c = conn.cursor()
-    
-    # データを削除
-    query = f"DELETE FROM {table} WHERE {column} = ?"
-    c.execute(query, (record,))
+        # クエリの作成
+        columns = ", ".join(columns_list)
+        values = ", ".join(values_list)
+        query = f"INSERT INTO {self.table} ({columns}) VALUES ({values})"
 
-    # クエリによって実行された変更をデータベースにコミット
-    conn.commit()
-
-    # データベースとの接続を閉じる
-    conn.close()
-
-def get_data(db:str,table:str,key:str,id:int) -> list:
-    """
-        データベースからデータを取得する
-
-        Args:
-            db (str): データベースのパス
-            table (str): データベースの作業テーブル
-            key (str): 検索対象となるカラム
-            id (int): 検索対象のid
-            
-        Returns:  
-            results_list (list): 
-    """
-
-    # データベースに接続
-    conn = connect_database(db)
-    c = conn.cursor()
-
-    #クエリに問題がないかチェック
-    check_input_query([table,key])
-
-    # table内からidと一意するデータをkey(カラム)の中から検索し,全カラムのデータを所得する
-    # 形式:[(カラム1-1,カラム2-1,カラム3-1,・・・),(カラム2-1,カラム2-2,カラム3-2,・・・),・・・]
-    query = f"SELECT * FROM {table} WHERE {key} = ?"
-    c.execute(query, (id,))
-    results_list = c.fetchall()
-
-    # 検索結果が0件(存在しない)場合404エラーを発生
-    if len(results_list)==0:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Data that meet the specified conditions do not exist.") 
+        # データベースに接続
+        c = self._open_connection_with_db()
         
-    #データベースとの接続を閉じる
-    conn.close()
+        # データベースに対してクエリを実行
+        c.execute(query)
 
-    return results_list
+        # クエリによって実行された変更をデータベースにコミット
+        self.conn.commit()
 
-def get_all_data_from_db(db:str,table:str) -> list:
-    """
-        指定したテーブルの全データをデータベースから取得する
+        # データベースとの接続を閉じる
+        self._close_connection_with_db()
 
-        Args:
-            db (str): データベースのパス
-            table (str): データベースの作業テーブル
+    def deleting_db_data(self, column:str, record: int | str) -> None:
+        """
+            データベースのデータを削除
+
+            Args:
+                db (str): データベースのパス
+                table (str): 作業テーブルの名称
+                column (str): 検索カラム
+                record (int | str): 削除するレコード
+            Returns:  
+                None
+        """
+
+       # データベースに接続
+        c = self._open_connection_with_db()
+        
+        # データを削除
+        query = f"DELETE FROM {self.table} WHERE {column} = ?"
+        c.execute(query, (record,))
+
+        # クエリによって実行された変更をデータベースにコミット
+        self.conn.commit()
+
+        # データベースとの接続を閉じる
+        self._close_connection_with_db()
+
+    def get_data(self,key:str,id:int) -> list:
+        """
+            データベースからデータを取得する
+
+            Args:
+                db (str): データベースのパス
+                table (str): データベースの作業テーブル
+                key (str): 検索対象となるカラム
+                id (int): 検索対象のid
+                
+            Returns:  
+                results_list (list): 
+        """
+
+        # データベースに接続
+        c = self._open_connection_with_db()
+
+        #クエリに問題がないかチェック
+        check_input_query([self.table,key])
+
+        # table内からidと一意するデータをkey(カラム)の中から検索し,全カラムのデータを所得する
+        # 形式:[(カラム1-1,カラム2-1,カラム3-1,・・・),(カラム2-1,カラム2-2,カラム3-2,・・・),・・・]
+        query = f"SELECT * FROM {self.table} WHERE {key} = ?"
+        c.execute(query, (id,))
+        results_list = c.fetchall()
+
+        # 検索結果が0件(存在しない)場合404エラーを発生
+        if len(results_list)==0:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Data that meet the specified conditions do not exist.") 
             
-        Returns:  
-            all_data_in_table (list): テーブル内の全データ
-    """
+        #データベースとの接続を閉じる
+        self._close_connection_with_db()
 
-    # データベースに接続
-    conn = connect_database(db)
-    c = conn.cursor()
+        return results_list
 
-    #クエリに問題がないかチェック
-    check_input_query([table])
+    def get_all_data_from_db(self) -> list:
+        """
+            指定したテーブルの全データをデータベースから取得する
 
-    # table内から全データを取得
-    query = f"SELECT * FROM {table}"
-    c.execute(query)
-    all_data_in_table = c.fetchall()
+            Args:
+                db (str): データベースのパス
+                table (str): データベースの作業テーブル
+                
+            Returns:  
+                all_data_in_table (list): テーブル内の全データ
+        """
 
-    #データベースとの接続を閉じる
-    conn.close()
+        # データベースに接続
+        c = self._open_connection_with_db()
 
-    return all_data_in_table
+        #クエリに問題がないかチェック
+        check_input_query([self.table])
 
+        # table内から全データを取得
+        query = f"SELECT * FROM {self.table}"
+        c.execute(query)
+        all_data_in_table = c.fetchall()
 
-def count_record(db:str,table:str,key:str) -> int:
-    """
-        データベースのカラムが持つデータ数をカウント
+        #データベースとの接続を閉じる
+        self._close_connection_with_db()
 
-        Args:
-            db (str): データベースのパス
-            table (str): データベースの作業テーブル
-            key (str): カウント対象のカラム
-            
-        Returns:  
-            count (int): データ数 
-    """
+        return all_data_in_table
 
-    # データベースに接続
-    conn = connect_database(db)
-    c = conn.cursor()
+    def count_record(self,key:str) -> int:
+        """
+            データベースのカラムが持つデータ数をカウント
 
-    # クエリに問題がないかチェック
-    check_input_query([table,key])
+            Args:
+                db (str): データベースのパス
+                table (str): データベースの作業テーブル
+                key (str): カウント対象のカラム
+                
+            Returns:  
+                count (int): データ数 
+        """
 
-    # table内のkey(カラム)に要素が何個あるかをカウントし取得
-    query = f"SELECT COUNT({key}) FROM {table}"
-    c.execute(query)
-    count = c.fetchone()[0]
+        # データベースに接続
+        c = self._open_connection_with_db()
 
-    # データベースとの接続を閉じる
-    conn.close()
+        # クエリに問題がないかチェック
+        check_input_query([self.table,key])
 
-    return count
+        # table内のkey(カラム)に要素が何個あるかをカウントし取得
+        query = f"SELECT COUNT({key}) FROM {self.table}"
+        c.execute(query)
+        count = c.fetchone()[0]
+
+        # データベースとの接続を閉じる
+        self._close_connection_with_db()
+
+        return count
 
 if __name__ == '__main__':
     #add_data('database/.db',enemy_car_data,[car_id, path_img, name, luk, text],[20, 'path', 'name', 4, 'text'])

--- a/api/database/database_operation.py
+++ b/api/database/database_operation.py
@@ -2,23 +2,29 @@ import sqlite3
 from validator.database_validator import connect_database,check_input_query
 from fastapi import  HTTPException,status
 
-def add_data(db:str,command:str):
+def add_data(db:str,table:str,columns_list:list,values_list:list):
     """
         データベースにデータを追加する
 
         Args:
             db (str): データベースのパス
-            command (str): データベースのクエリ
+            table (str): 作業テーブルの名称
+            
             
         Returns:  
     """
+
+    # クエリの作成
+    columns = ", ".join(columns_list)
+    values = ", ".join(values_list)
+    query = "INSERT INTO " + table + " (" + columns + ") VALUES ("+ values +")"
 
     # データベースに接続
     conn = connect_database(db)
     c = conn.cursor()
     
     # データベースに対してクエリを実行
-    c.execute(command)
+    c.execute(query)
 
     # クエリによって実行された変更をデータベースにコミット
     conn.commit()
@@ -94,5 +100,5 @@ def count_record(db:str,table:str,key:str) -> int:
     return count
 
 if __name__ == '__main__':
-    #add_data('car.db',"INSERT INTO enemy_car_data (car_id, path_img, name, luk, text) VALUES (2, 'database/car_img/car2.png', 'Feline Fury', 4, 'With its sleek exterior, cozy interior, and advanced features such as a built-in laser pointer for entertainment, this car is perfectly designed for cat lovers. You can be assured that every drive will feel like a catwalk. Meowvelous!')")
+    #add_data('car.db',[car_id, path_img, name, luk, text],[20, 'path', 'name', 4, 'text'])
     pass

--- a/api/database/database_operation.py
+++ b/api/database/database_operation.py
@@ -33,6 +33,32 @@ def adding_data_to_db(db:str,table:str,columns_list:list,values_list:list) -> No
     # データベースとの接続を閉じる
     conn.close()
 
+def deleting_db_data(db:str,table:str, column:str, record: int | str) -> None:
+    """
+        データベースのデータを削除
+
+        Args:
+            db (str): データベースのパス
+            table (str): 作業テーブルの名称
+            column (str): 検索カラム
+            record (int | str): 削除するレコード
+        Returns:  
+            None
+    """
+
+    # データベースに接続
+    conn = connect_database(db)
+    c = conn.cursor()
+    
+    # データを削除
+    query = f"DELETE FROM {table} WHERE {column} = ?"
+    c.execute(query, (record,))
+
+    # クエリによって実行された変更をデータベースにコミット
+    conn.commit()
+
+    # データベースとの接続を閉じる
+    conn.close()
 
 def get_data(db:str,table:str,key:str,id:int) -> list:
     """

--- a/api/database/database_operation.py
+++ b/api/database/database_operation.py
@@ -106,7 +106,7 @@ class DatabaseOperator():
         # データベースとの接続を閉じる
         self._close_connection_with_db()
 
-    def get_data(self,key:str,id:int) -> list:
+    def get_data_from_db(self,key:str,id:int) -> list:
         """
             データベースからデータを取得する
 

--- a/api/database/database_operation.py
+++ b/api/database/database_operation.py
@@ -2,22 +2,23 @@ import sqlite3
 from validator.database_validator import connect_database,check_input_query
 from fastapi import  HTTPException,status
 
-def add_data(db:str,table:str,columns_list:list,values_list:list):
+def adding_data_to_db(db:str,table:str,columns_list:list,values_list:list) -> None:
     """
         データベースにデータを追加する
 
         Args:
             db (str): データベースのパス
             table (str): 作業テーブルの名称
-            
-            
+            columns_list (list): テーブルが持つカラムのリスト
+            values_list (list): データベースに保存するデータのリスト,保存先はcolumns_listのインデックスと対応している
         Returns:  
+            None
     """
 
     # クエリの作成
     columns = ", ".join(columns_list)
     values = ", ".join(values_list)
-    query = "INSERT INTO " + table + " (" + columns + ") VALUES ("+ values +")"
+    query = f"INSERT INTO {table} ({columns}) VALUES ({values})"
 
     # データベースに接続
     conn = connect_database(db)
@@ -130,5 +131,5 @@ def count_record(db:str,table:str,key:str) -> int:
     return count
 
 if __name__ == '__main__':
-    #add_data('car.db',[car_id, path_img, name, luk, text],[20, 'path', 'name', 4, 'text'])
+    #add_data('database/.db',enemy_car_data,[car_id, path_img, name, luk, text],[20, 'path', 'name', 4, 'text'])
     pass

--- a/api/database/database_operation.py
+++ b/api/database/database_operation.py
@@ -69,6 +69,36 @@ def get_data(db:str,table:str,key:str,id:int) -> list:
 
     return results_list
 
+def get_all_data_from_db(db:str,table:str) -> list:
+    """
+        指定したテーブルの全データをデータベースから取得する
+
+        Args:
+            db (str): データベースのパス
+            table (str): データベースの作業テーブル
+            
+        Returns:  
+            all_data_in_table (list): テーブル内の全データ
+    """
+
+    # データベースに接続
+    conn = connect_database(db)
+    c = conn.cursor()
+
+    #クエリに問題がないかチェック
+    check_input_query([table])
+
+    # table内から全データを取得
+    query = f"SELECT * FROM {table}"
+    c.execute(query)
+    all_data_in_table = c.fetchall()
+
+    #データベースとの接続を閉じる
+    conn.close()
+
+    return all_data_in_table
+
+
 def count_record(db:str,table:str,key:str) -> int:
     """
         データベースのカラムが持つデータ数をカウント

--- a/api/main.py
+++ b/api/main.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from s3 import image_interacter
 from routes import race_routes , ending_routes ,database_routes,car_generation_routes
-from api_test import test_car_data,test_translation, no_rembg
+from api_test import test_car_data,test_translation, no_rembg,test_database
 
 app = FastAPI()
 
@@ -57,3 +57,6 @@ app.include_router(test_car_data.router)
 
 # 翻訳APIのルーター
 app.include_router(test_translation.router)
+
+# データベースのクエリ確認用
+app.include_router(test_database.router)

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -6,5 +6,6 @@ deepl
 transformers
 rembg
 pillow
+python-multipart
 flax
 

--- a/api/routes/database_routes.py
+++ b/api/routes/database_routes.py
@@ -43,7 +43,7 @@ def get_enemy_car( api_key: str = Security(validate_api_key)):
     car_id = random.randint(1, total_records)
 
     #データベースから敵の車データを取得
-    [list_car_data] = db_operator.get_data(key,car_id)
+    [list_car_data] = db_operator.get_data_from_db(key,car_id)
 
     #pathから画像を取得
     img = Image.open(list_car_data[1])

--- a/api/routes/database_routes.py
+++ b/api/routes/database_routes.py
@@ -1,5 +1,5 @@
 
-from database.database_operation import get_data,count_record
+from database.database_operation import DatabaseOperator
 from utils.auth import validate_api_key
 from fastapi import APIRouter, Security
 from PIL import Image
@@ -34,14 +34,16 @@ def get_enemy_car( api_key: str = Security(validate_api_key)):
     table = 'enemy_car_data' # テーブルの名称
     key = 'car_id' # 検索に使用するカラムの名前
 
+    db_operator = DatabaseOperator(db,table)
     #レコードの数
-    total_records = count_record(db,table,key)
+    total_records = db_operator.count_record(key)
+
 
     #ランダムに車を選択
     car_id = random.randint(1, total_records)
 
     #データベースから敵の車データを取得
-    [list_car_data] = get_data(db,table,key,car_id)
+    [list_car_data] = db_operator.get_data(key,car_id)
 
     #pathから画像を取得
     img = Image.open(list_car_data[1])


### PR DESCRIPTION
## 目的
database_operationを修正
## 概要
データベースにデータを追加,削除するAPIを作成
テーブル内のデータ一覧を取得するAPIを作成
database_operation内の関数をクラスで管理


## 確認項目
APIの確認
- [x] /create/enemy が正常に動作する
- [x] /test/database/get_allでenemy_carテーブル内のデータ一覧が見れる
- [x] /test/database/add_dataで
db = database/.db,table = database/.db
columns_list = car_id,path_img,name,luk,text
values_list = 20,"path","tomato",1,"美味しい"
と入力し,実行した後,test/database/get_allを実行すると最後の方にデータが追加されていることを確認.
- [x] /test/database/delete_dataで
db = database/.db
table = database/.db
column = car_id
record = 20
として実行.est/database/get_allを実行すると先程追加したデータが消えていることを確認.

## 不安・相談
クラスでまとめる場合
のように使う場合,名前は
db_operator.get_data_from_db(key,car_id)-> db_operator.get_data(key,car_id)
の方が良い？