### PR TITLE
ChatGPTの出力に対して検証を行う機能を改善.

### DIFF
--- a/api/chat_gpt/ending_generation.py
+++ b/api/chat_gpt/ending_generation.py
@@ -1,6 +1,6 @@
 from openai import OpenAI
 from models import GameEndingModel
-from validator.chat_gpt_validator import ChatgptOutputValidator
+from validator.chat_gpt_validator import ChatGptOutputValidator
 import random
 
 client = OpenAI()
@@ -104,14 +104,14 @@ def ending_generate_chatgpt(race_moderate:GameEndingModel,text_rust_event:str,fi
     text_split:list = [] # ChatGPTの出力を項目ごとに分割し保存するリスト
     item_count_in_format:int = 3 # フォーマットで指定したChatGPTの出力項目
     
-    chatgpt_output_validator = ChatgptOutputValidator()
+    chatgpt_output_validator = ChatGptOutputValidator()
     
     # プロンプトの作成
     system_prompt,user_prompt = shaping_prompts_ending_generate(text_rust_event,first_car_name,second_car_name,third_car_name,fourth_car_name,race_moderate.player_car_name,race_moderate.player_car_instruction,race_moderate.player_luck)
 
     # ChatGPTがフォーマットに則った出力を行わない場合,もう一度生成を行う(3回まで)
     # 問題がない場合,ChatGPTでエンディングを生成する.
-    while(chatgpt_output_validator.validate_scenario_generated_chatgpt(item_count_in_format,text_split)):
+    while(chatgpt_output_validator.validate_scenario_generated_by_chatgpt(item_count_in_format,text_split)):
 
         # gpt-3.5-turboを使用,最大出力トークン数は300
         res = client.chat.completions.create(

--- a/api/chat_gpt/race_progression.py
+++ b/api/chat_gpt/race_progression.py
@@ -1,5 +1,5 @@
 from openai import OpenAI
-from validator.chat_gpt_validator import ChatgptOutputValidator
+from validator.chat_gpt_validator import ChatGptOutputValidator
 from models import RaceModeratorModel
 
 
@@ -82,11 +82,11 @@ def race_moderator_chatgpt(ending_model:RaceModeratorModel):
     text_split:list = [] # ChatGPTの出力を項目ごとに分割し保存するリスト
     item_count_in_format:int = 11 # フォーマットで指定したChatGPTの出力項目
 
-    chatgpt_output_validator = ChatgptOutputValidator()
+    chatgpt_output_validator = ChatGptOutputValidator()
 
     # ChatGPTがフォーマットに則った出力を行わない場合,もう一度生成を行う(3回まで)
     # 問題がない場合レースのシナリオを生成する
-    while(chatgpt_output_validator.validate_scenario_generated_chatgpt(item_count_in_format,text_split)):
+    while(chatgpt_output_validator.validate_scenario_generated_by_chatgpt(item_count_in_format,text_split)):
         prompt_system,prompt_user = shaping_prompts_rece_moderator(ending_model)
 
         # gpt-3.5-turboを使用,最大出力トークン数は200

--- a/api/chat_gpt/race_progression.py
+++ b/api/chat_gpt/race_progression.py
@@ -1,5 +1,5 @@
 from openai import OpenAI
-from validator.chat_gpt_validator import validate_chat_gpt_output_count
+from validator.chat_gpt_validator import ChatgptOutputValidator
 from models import RaceModeratorModel
 
 
@@ -79,13 +79,14 @@ def race_moderator_chatgpt(ending_model:RaceModeratorModel):
             fourth (str): ４位の車名
     """
 
-    number_of_generation:int = 0 # ChatGPTで生成を行った回数
     text_split:list = [] # ChatGPTの出力を項目ごとに分割し保存するリスト
     item_count_in_format:int = 11 # フォーマットで指定したChatGPTの出力項目
 
+    chatgpt_output_validator = ChatgptOutputValidator()
+
     # ChatGPTがフォーマットに則った出力を行わない場合,もう一度生成を行う(3回まで)
     # 問題がない場合レースのシナリオを生成する
-    while(not(validate_chat_gpt_output_count(text_split,item_count_in_format,number_of_generation))): 
+    while(chatgpt_output_validator.validate_scenario_generated_chatgpt(item_count_in_format,text_split)):
         prompt_system,prompt_user = shaping_prompts_rece_moderator(ending_model)
 
         # gpt-3.5-turboを使用,最大出力トークン数は200
@@ -105,9 +106,6 @@ def race_moderator_chatgpt(ending_model:RaceModeratorModel):
         # 出力フォーマットで項目ごとに"|"で区切ることを指定しているため,ChatGPTの出力を"|"で分割.
         text_split = response.split('|')
         #text_split=[i for i in range(8)]
-
-        # ChatGPTでの生成回数をカウント
-        number_of_generation += 1
 
     # ChatGPTの出力から順位とイベントを抽出
     first = text_split[2].replace('\n','')

--- a/api/chat_gpt/status_generation.py
+++ b/api/chat_gpt/status_generation.py
@@ -1,5 +1,5 @@
 from openai import OpenAI
-from validator.chat_gpt_validator import validate_chat_gpt_output_count,validate_luk_is_number
+from validator.chat_gpt_validator import ChatgptOutputValidator
 client = OpenAI()
 
 def shaping_prompts_status_generate(user_input:str):
@@ -40,18 +40,18 @@ async def status_generate_chatgpt(user_input:str):
             prompt (str): 
     """
     
-    number_of_generation:int = 0 # ChatGPTで生成を行った回数
     text_split:list = [] # ChatGPTの出力を項目ごとに分割し保存するリスト
     item_count_in_format = 7 # フォーマットで指定したChatGPTの出力項目
+
+    chatgpt_output_validator = ChatgptOutputValidator()
 
     # プロンプトの作成
     system_prompt,user_prompt = shaping_prompts_status_generate(user_input)
 
     # ChatGPTがフォーマットに則った出力を行わない場合,もう一度生成を行う(3回まで)
     # 問題がない場合,車の外見やステータスを生成
-    while(not(validate_chat_gpt_output_count(text_split,item_count_in_format,number_of_generation) 
-            and validate_luk_is_number(text_split[2],number_of_generation))):
-   
+    while(chatgpt_output_validator.validate_car_generated_chatgpt(item_count_in_format,text_split)):
+
         # gpt-3.5-turboを使用,最大出力トークン数は100
         res = client.chat.completions.create(
         model="gpt-3.5-turbo", 
@@ -71,8 +71,6 @@ async def status_generate_chatgpt(user_input:str):
         #text_split=['LUK',1,2]
         #text_split=[0,1,2,3]
 
-        # ChatGPTでの生成回数をカウント
-        number_of_generation += 1
 
     # ChatGPTの出力から車の運勢パラメータ,車名,設定文を抽出
     luk = int(text_split[2])                         # 運勢パラメータ

--- a/api/chat_gpt/status_generation.py
+++ b/api/chat_gpt/status_generation.py
@@ -1,5 +1,5 @@
 from openai import OpenAI
-from validator.chat_gpt_validator import ChatgptOutputValidator
+from validator.chat_gpt_validator import ChatGptOutputValidator
 client = OpenAI()
 
 def shaping_prompts_status_generate(user_input:str):
@@ -43,7 +43,7 @@ async def status_generate_chatgpt(user_input:str):
     text_split:list = [] # ChatGPTの出力を項目ごとに分割し保存するリスト
     item_count_in_format = 7 # フォーマットで指定したChatGPTの出力項目
 
-    chatgpt_output_validator = ChatgptOutputValidator()
+    chatgpt_output_validator = ChatGptOutputValidator()
 
     # プロンプトの作成
     system_prompt,user_prompt = shaping_prompts_status_generate(user_input)

--- a/api/validator/chat_gpt_validator.py
+++ b/api/validator/chat_gpt_validator.py
@@ -2,9 +2,34 @@ import random
 from fastapi import  HTTPException,status
 from transformers import GPT2Tokenizer
 
-def validate_chat_gpt_output_count(result:list,item_count_in_format:int,error_count:int) -> bool:
+class ChatgptOutputValidator():
+    def __init__(self) -> None:
+        self.error_count = 0
+        
+    def _luk_is_number(self,output_chatgpt:str) -> bool:
+        """
+        ChatGPTが出力した車のlukが数字になっているか確認
+        3回失敗したらエラーを出力
+        Args:
+            result (list): ChatGPTの出力を分割して格納したリスト.
+            error_count (int): フォーマットに従わない出力が行われた回数
+        Returns:
+            bool: returnは正常/異常(1/0)
+        Raises:
+            HTTP_408_REQUEST_TIMEOUT: ChatGPTが LUK(int)|NAME(str)|TEXT(str) のフォーマットに従っていない.
+        """
+        # lukが数値になっているか?
+        try:
+            _ = int(output_chatgpt)
+            
+            return False
+        except:
+            print("generated luck value:" + str(output_chatgpt))
 
-    """
+            return True
+
+    def _output_items_count_is_rightness(self,item_count_in_format:int,output_chatgpt:list) -> bool:
+        """
         ChatGPTが出力した項目の数がフォーマットに則っているか確認する
         3回失敗したらエラーを出力
         Args:
@@ -15,51 +40,51 @@ def validate_chat_gpt_output_count(result:list,item_count_in_format:int,error_co
             bool: returnは正常/異常(1/0)
         Raises:
             HTTP_408_REQUEST_TIMEOUT: ChatGPTの出力がフォーマットに則っていない
-    """
-    
-    # 出力された項目の数が指定のものと一致すか. 一致/不一致(True/False)
-    # 判定を行うたびにerror_countを増加させ,4回になった際に408エラーを発生.
-    if len(result) == item_count_in_format:
-        return True
-    else:
-        print("Number of items output:"+str(len(result))+"Output_text" + str(result))
-        if error_count >= 4:
+        """
+        # 出力された項目の数が指定のものと一致すか. 一致/不一致(True/False)
+        # 判定を行うたびにerror_countを増加させ,4回になった際に408エラーを発生.
+        if len(output_chatgpt) == item_count_in_format:
+            return False
+        else:
+            print("Number of items output:"+str(len(output_chatgpt))+",Output_text" + str(output_chatgpt))
+
+            return True
+
+    def validate_car_generated_chatgpt(self,item_count_in_format:int,output_chatgpt:list):
+        print(output_chatgpt)
+        if self._output_items_count_is_rightness(item_count_in_format,output_chatgpt):
+            self.error_count += 1
+
+        elif self._luk_is_number(output_chatgpt[2]):
+            self.error_count += 1
+
+        else:
+            return False
+
+
+        if self.error_count >= 4:
             raise HTTPException(
                 status_code=status.HTTP_408_REQUEST_TIMEOUT,
                 detail="ChatGPT output does not follow the format",
             )
-        else:
-            return False
-
-def validate_luk_is_number(output_chatgpt:int,error_count:int) -> bool:
-
-    """
-        ChatGPTが出力した車のlukが数字になっているか確認
-        3回失敗したらエラーを出力
-        Args:
-            result (list): ChatGPTの出力を分割して格納したリスト.
-            error_count (int): フォーマットに従わない出力が行われた回数
-        Returns:
-            bool: returnは正常/異常(1/0)
-        Raises:
-            HTTP_408_REQUEST_TIMEOUT: ChatGPTが LUK(int)|NAME(str)|TEXT(str) のフォーマットに従っていない.
-    """
-
-    # lukが数値になっているか?
-    # # 判定を行うたびにerror_countを増加させ,4回になった際に408エラーを発生.
-    try:
-        _ = int(output_chatgpt)
         
         return True
-    except:
-        print("generated luck value" + str(output_chatgpt))
-        if error_count >= 4:
+
+    def validate_scenario_generated_chatgpt(self,item_count_in_format:int,output_chatgpt:list):
+        print(output_chatgpt)
+        if self._output_items_count_is_rightness(item_count_in_format,output_chatgpt):
+            self.error_count += 1
+        else:
+            return False
+
+        if self.error_count >= 4:
             raise HTTPException(
                 status_code=status.HTTP_408_REQUEST_TIMEOUT,
                 detail="ChatGPT output does not follow the format",
             )
-        else:
-            return False
+        
+        return True
+
 
 
 tokenizer = GPT2Tokenizer.from_pretrained("gpt2")

--- a/api/validator/chat_gpt_validator.py
+++ b/api/validator/chat_gpt_validator.py
@@ -2,7 +2,7 @@ import random
 from fastapi import  HTTPException,status
 from transformers import GPT2Tokenizer
 
-class ChatgptOutputValidator():
+class ChatGptOutputValidator():
     def __init__(self) -> None:
         self.error_count = 0
         
@@ -14,7 +14,7 @@ class ChatgptOutputValidator():
             result (list): ChatGPTの出力を分割して格納したリスト.
             error_count (int): フォーマットに従わない出力が行われた回数
         Returns:
-            bool: returnは正常/異常(1/0)
+            bool: returnは正常/異常(0/1)
         Raises:
             HTTP_408_REQUEST_TIMEOUT: ChatGPTが LUK(int)|NAME(str)|TEXT(str) のフォーマットに従っていない.
         """
@@ -22,13 +22,13 @@ class ChatgptOutputValidator():
         try:
             _ = int(output_chatgpt)
             
-            return False
+            return True
         except:
             print("generated luck value:" + str(output_chatgpt))
 
-            return True
+            return False
 
-    def _output_items_count_is_rightness(self,item_count_in_format:int,output_chatgpt:list) -> bool:
+    def _is_correct_gpt_output(self,item_count_in_format:int,output_chatgpt:list) -> bool:
         """
         ChatGPTが出力した項目の数がフォーマットに則っているか確認する
         3回失敗したらエラーを出力
@@ -37,25 +37,25 @@ class ChatgptOutputValidator():
             item_count_in_format (int): フォーマットで指定した出力項目の数
             error_count (int): フォーマットに従わない出力が行われた回数
         Returns:
-            bool: returnは正常/異常(1/0)
+            bool: returnは正常/異常(0/1)
         Raises:
             HTTP_408_REQUEST_TIMEOUT: ChatGPTの出力がフォーマットに則っていない
         """
         # 出力された項目の数が指定のものと一致すか. 一致/不一致(True/False)
         # 判定を行うたびにerror_countを増加させ,4回になった際に408エラーを発生.
         if len(output_chatgpt) == item_count_in_format:
-            return False
+            return True
         else:
             print("Number of items output:"+str(len(output_chatgpt))+",Output_text" + str(output_chatgpt))
 
-            return True
+            return False
 
     def validate_car_generated_chatgpt(self,item_count_in_format:int,output_chatgpt:list):
         print(output_chatgpt)
-        if self._output_items_count_is_rightness(item_count_in_format,output_chatgpt):
+        if not(self._is_correct_gpt_output(item_count_in_format,output_chatgpt)):
             self.error_count += 1
 
-        elif self._luk_is_number(output_chatgpt[2]):
+        elif not(self._luk_is_number(output_chatgpt[2])):
             self.error_count += 1
 
         else:
@@ -70,9 +70,9 @@ class ChatgptOutputValidator():
         
         return True
 
-    def validate_scenario_generated_chatgpt(self,item_count_in_format:int,output_chatgpt:list):
+    def validate_scenario_generated_by_chatgpt(self,item_count_in_format:int,output_chatgpt:list):
         print(output_chatgpt)
-        if self._output_items_count_is_rightness(item_count_in_format,output_chatgpt):
+        if not(self._is_correct_gpt_output(item_count_in_format,output_chatgpt)):
             self.error_count += 1
         else:
             return False


### PR DESCRIPTION
## 目的
エラーの発生回数を外部でカウントしていたため,内部でカウントするように変更
## 概要
validate_chat_gpt_output_countと
validate_luk_is_number
をクラスにし,エラーのカウント回数をクラスが保持するようにした.

## 確認項目

- [x] api/chat_gpt/ending_generation.py 132行目
api/chat_gpt/race_progression.py 108行目
api/chat_gpt/status_generation.py 71行目
のコメントアウトを外し,
/car/create/
/race/middle_part
/race/ending
が408エラーを発生させることを確認
- [x] 再度コメントアウトし,
/car/create/
/race/middle_part
/race/ending
が動作することを確認.

## 不安・相談
