### PR TITLE
[CICD] mainにpush時に自動的にデプロイするためのWorkflowを追加

### DIFF
--- a/.github/workflows/auto_deploy.yml
+++ b/.github/workflows/auto_deploy.yml
@@ -1,0 +1,32 @@
+name: Auto Deploy
+run-name: ChatGP is deploying
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+      - name: Deploy
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.SSH_HOST_HACKASON}}
+          username: ${{ secrets.SSH_USERNAME_HACKASON}}
+          key: ${{ secrets.SSH_PRIVATE_KEY_HACKASON}}
+          port: ${{ secrets.SSH_PORT_HACKASON}}
+          script: |
+            cd ~/ChatGP
+            git pull origin main
+            git checkout main
+            docker-compose -f docker-compose.prod.yml build
+            docker compose -f docker-compose.prod.yml run --rm view yarn
+            docker compose -f docker-compose.prod.yml run --rm view yarn build
+            docker compose -f docker-compose.prod.yml up -d

--- a/.github/workflows/auto_deploy.yml
+++ b/.github/workflows/auto_deploy.yml
@@ -26,7 +26,5 @@ jobs:
             cd ~/ChatGP
             git pull origin main
             git checkout main
-            docker-compose -f docker-compose.prod.yml build
-            docker compose -f docker-compose.prod.yml run --rm view yarn
-            docker compose -f docker-compose.prod.yml run --rm view yarn build
-            docker compose -f docker-compose.prod.yml up -d
+            bash script/down.sh
+            bash script/up.sh

--- a/README.md
+++ b/README.md
@@ -24,6 +24,26 @@ docker compose -f docker-compose.prod.yml run --rm view yarn build
 docker compose -f docker-compose.prod.yml up -d
 ```
 
+### Deletion
+
+```bash
+docker compose -f docker-compose.prod.yml down
+```
+
+### Use Script
+
+Installtionをまとめて実行
+
+```bash
+$ bash ./script/up.sh
+```
+
+Deletionを実行
+
+```bash
+$ bash ./script/down.sh
+```
+
 ## File Structure
 
 - `api/`
@@ -34,6 +54,9 @@ docker compose -f docker-compose.prod.yml up -d
 
   - Next.js を用いてフロントエンドを構築
 
+- `script/`
+
+  - インストールや削除を行うシェルスクリプト
 
 - `docker-compose.yml`
   - 複数のコンテナを定義し、実行するための設定

--- a/script/down.sh
+++ b/script/down.sh
@@ -1,0 +1,1 @@
+docker-compose -f docker-compose.prod.yml down

--- a/script/up.sh
+++ b/script/up.sh
@@ -1,0 +1,4 @@
+docker-compose -f docker-compose.prod.yml build
+docker compose -f docker-compose.prod.yml run --rm view yarn
+docker compose -f docker-compose.prod.yml run --rm view yarn build
+docker compose -f docker-compose.prod.yml up -d


### PR DESCRIPTION
## 目的
[CICD] mainにpush時に自動的にデプロイするためのWorkflowを追加
PR通過時は自動的にmainがpushされるので、その場合でもデプロイが走る
## 概要
- デプロイ用のWorkflowを追加
- Tailscaleやデプロイサーバーの機密情報をGitHub Secretsに追加
- デプロイ用にシェルスクリプトを作成
- 作成したシェルスクリプトについてREADMEの追記
## 確認項目

- [ ] READMEの変更事項の確認
- [ ] シェルスクリプトの動作確認 ( 本番環境 )
- [ ] このWorkflow自体のテストはmainにマージしないとわからないので詳細は以下に書いています

## 不安・相談
このPRをマージして更に`develop`から`main`にマージした時に自動デプロイが走るはずなのでそれをチェックしてほしい
確認方法としては本番環境で一度ChatGPを落とした後、マージを通して自動的にデプロイされるかチェックしたい
